### PR TITLE
fix:dartsass削除しデプロイ時のエラー修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,8 +70,6 @@ gem "sentry-ruby", "~> 5.14"
 
 gem "sentry-rails", "~> 5.14"
 
-gem "dartsass-rails", "~> 0.5.0"
-
 gem "cssbundling-rails", "~> 1.3"
 
 gem 'sorcery', "0.16.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,9 +98,6 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.3.3)
       railties (>= 6.0.0)
-    dartsass-rails (0.5.0)
-      railties (>= 6.0.0)
-      sass-embedded (~> 1.63)
     date (3.3.4)
     debug (1.8.0)
       irb (>= 1.5.0)
@@ -124,9 +121,6 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    google-protobuf (3.25.1-aarch64-linux)
-    google-protobuf (3.25.1-arm64-darwin)
-    google-protobuf (3.25.1-x86_64-linux)
     hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -265,12 +259,6 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sass-embedded (1.69.5-aarch64-linux-gnu)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-arm64-darwin)
-      google-protobuf (~> 3.23)
-    sass-embedded (1.69.5-x86_64-linux-gnu)
-      google-protobuf (~> 3.23)
     selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -340,7 +328,6 @@ DEPENDENCIES
   bootsnap
   capybara
   cssbundling-rails (~> 1.3)
-  dartsass-rails (~> 0.5.0)
   debug
   dockerfile-rails (>= 1.5)
   factory_bot_rails

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,2 @@
 web: bin/rails server -p 3000
-css: bin/rails dartsass:watch
-css: yarn watch:css
-css: yarn watch:css
 css: bin/rails tailwindcss:watch


### PR DESCRIPTION
概要
デプロイ時に下記のエラーが発生した。
```
=> ERROR [build 10/10] RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile  
Error: failed to fetch an image or build from source: error building: failed to solve: executor failed running [/bin/sh -c SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile]: exit code: 1
```
ローカルのサーバでも`Error reading app/assets/stylesheets/application.scss: Cannot open file.`と表示されていた。

bootstrapからtailswindcssに変更し、dartsassが不要であったためgemfileにて`dartsass-rails`を削除。
Procfile.devファイルのdartに関する行などを削除した。

サーバー起動時のエラーが消えていた。
