### PR TITLE
style:画像のパスをurlからimage_pathに変更

### DIFF
--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -1,4 +1,3 @@
 <!-- component -->
-<div class="flex h-screen w-full items-center justify-center bg-gray-900 bg-cover bg-no-repeat" style="background-image:url('assets/top.jpg')">
-  <%= turbo_frame_tag "user_form" %>
+<div class="flex h-screen w-full items-center justify-center bg-gray-900 bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpg') %>')">
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,10 +1,9 @@
 <!-- component -->
-<div class="flex h-screen w-full items-center justify-center bg-gray-900 bg-cover bg-no-repeat" style="background-image:url('/assets/top.jpg')">
-  <%= turbo_frame_tag "user_form" do %>
+<div class="flex h-screen w-full items-center justify-center bg-gray-900 bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpg') %>')">
   <div class="rounded-xl bg-gray-800 bg-opacity-50 px-16 py-10 shadow-lg backdrop-blur-md max-sm:px-8">
     <div class="text-white">
       <div class="mb-8 flex flex-col items-center">
-        <img src="/assets/my_dog.jpg" width="150" alt="" srcset="" />
+        <img src="<%= image_path('my_dog.jpg') %>" width="150" alt="" srcset="" />
       </div>
       <%= form_with model: @user, local: true do |f| %>
         <div class="mb-4 text-lg flex flex-col">
@@ -29,5 +28,4 @@
       <% end %>
     </div>
   </div>
-  <% end %>
 </div>

--- a/fly.toml
+++ b/fly.toml
@@ -1,13 +1,16 @@
-# fly.toml app configuration file generated for crazy-challenge-record on 2023-12-14T19:34:23+09:00
+# fly.toml app configuration file generated for crazy-man on 2023-12-20T21:20:25+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "crazy-challenge-record"
+app = "crazy-man"
 primary_region = "nrt"
 console_command = "/rails/bin/rails console"
 
 [build]
+
+[deploy]
+  release_command = "./bin/rails db:prepare"
 
 [http_service]
   internal_port = 3000
@@ -39,6 +42,3 @@ console_command = "/rails/bin/rails console"
 [[statics]]
   guest_path = "/rails/public"
   url_prefix = "/"
-[deploy]
-  release_command = "./bin/rails db:prepare"
-


### PR DESCRIPTION
概要
デプロイ時に背景画像が表示されず原因が下記の表記だからだと推測される。
`url('/assets/top.jpg')`
上記の表記を`<%= image_path('top.jpg') %>`に変更。