### PR TITLE
fix:node.jsとyarnのバージョン変更

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-yarn-path ".yarn/releases/yarn-1.22.21.cjs"
+yarn-path ".yarn/releases/yarn-1.22.19.cjs"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,4 @@
 {
-  "engines": {
-    "node": "18.0.0",
-    "yarn": "1.22.21"
-  },
   "dependencies": {
     "autoprefixer": "^10.4.16",
     "nodemon": "^3.0.2",
@@ -16,5 +12,5 @@
   "browserslist": [
     "defaults"
   ],
-  "packageManager": "yarn@1.22.21"
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
概要
herokuへのデプロイ時、node.jsとyarnのバージョンのずれで警告が発生するため
herokuのバージョンにローカルも合わせた