### PR TITLE
fix:削除によるエラーの解決

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -37,6 +37,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    @post.post_categories.destroy_all
     @post.destroy!
     redirect_to posts_path, flash: { success: t('posts.destroy.success') }
   end


### PR DESCRIPTION
多対多による影響で、投稿が削除できなかった。
これは、中間テーブルを削除するコードがpostsコントローラdeleteアクションになかったため、それがエラーの原因となったため、投稿を削除する前に中間テーブルの内容を削除することで、エラーが解決した。