### PR TITLE
fix:いいね画像のpng追加によるカウントされない問題修正

### DIFF
--- a/app/views/posts/_likes_count.html.erb
+++ b/app/views/posts/_likes_count.html.erb
@@ -1,4 +1,4 @@
-<% like_button_type = like_image_for(post).gsub('likes/', '').gsub('_2', '') %>
+<% like_button_type = like_image_for(post).gsub('likes/', '').gsub('_2.png', '') %>
 <% count = like_count_for_button(post, like_button_type + '_2') %>
 <div id="likes_count-<%= post.id %>" class="font-bold text-black">
   <%= count.to_s %>


### PR DESCRIPTION
imga_tagにpng拡張子を追加したことで、いいね画像がカウントされなかったため修正した。