### PR TITLE
Natural language APIの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@
 /node_modules
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/.env

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,4 @@
 /app/assets/builds/*
 !/app/assets/builds/.keep
 
-/.env
+/app/services/service_account.json

--- a/Gemfile
+++ b/Gemfile
@@ -89,4 +89,6 @@ gem 'rails-i18n', '~> 7.0.0'
 
 gem 'enum_help'
 
-gem 'dotenv-rails'
+gem 'faraday'
+
+gem 'googleauth'

--- a/Gemfile
+++ b/Gemfile
@@ -88,3 +88,5 @@ gem 'carrierwave', '~> 3.0'
 gem 'rails-i18n', '~> 7.0.0'
 
 gem 'enum_help'
+
+gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,10 +113,6 @@ GEM
     diff-lcs (1.5.0)
     dockerfile-rails (1.5.12)
       rails (>= 3.0.0)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     enum_help (0.0.19)
@@ -137,6 +133,15 @@ GEM
     ffi (1.16.3)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-cloud-env (2.1.0)
+      faraday (>= 1.0, < 3.a)
+    googleauth (1.9.1)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
     hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -172,6 +177,7 @@ GEM
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.4)
@@ -203,6 +209,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
+    os (1.1.4)
     parallel (1.23.0)
     parser (3.2.2.4)
       ast (~> 2.4.1)
@@ -319,6 +326,11 @@ GEM
       sentry-ruby (~> 5.14.0)
     sentry-ruby (5.14.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    signet (0.18.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
     slop (3.6.0)
     snaky_hash (2.0.1)
       hashie
@@ -384,10 +396,11 @@ DEPENDENCIES
   cssbundling-rails (~> 1.3)
   debug
   dockerfile-rails (>= 1.5)
-  dotenv-rails
   enum_help
   factory_bot_rails
   faker
+  faraday
+  googleauth
   importmap-rails
   jbuilder
   pg (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,10 @@ GEM
     diff-lcs (1.5.0)
     dockerfile-rails (1.5.12)
       rails (>= 3.0.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     drb (2.2.0)
       ruby2_keywords
     enum_help (0.0.19)
@@ -380,6 +384,7 @@ DEPENDENCIES
   cssbundling-rails (~> 1.3)
   debug
   dockerfile-rails (>= 1.5)
+  dotenv-rails
   enum_help
   factory_bot_rails
   faker

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,11 +13,23 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params)
-    if @post.save
-      redirect_to posts_path, flash: { success: t('posts.create.success') }
-    else
-      flash.now[:error] = t('.fail')
-      render :new, status: :unprocessable_entity
+    moderation_service = ContentModerationService.new(@post.content)
+    begin
+      result = moderation_service.analyze
+      categories = result['moderationCategories'].to_a
+      high_confidence = categories.any? { |category| category['confidence'] > 0.8 }
+      if high_confidence
+        flash.now[:error] = t('.fail')
+        render :new, status: :unprocessable_entity
+      else
+        @post.save
+        redirect_to posts_path, flash: { success: t('posts.create.success') }
+      end
+    rescue => e
+      # エラー時の処理
+      logger.error(e.message)
+      flash[:error] = 'Content analysis failed.'
+      render :new
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,20 +18,24 @@ class PostsController < ApplicationController
       result = moderation_service.analyze
       categories = result['moderationCategories'].to_a
       high_confidence = categories.any? { |category| category['confidence'] > 0.8 }
+
       if high_confidence
         high_confidence_categories = categories.select { |category| category['confidence'] > 0.8 }
         inappropriate_content = high_confidence_categories.map { |category| t("moderation_categories.#{category['name']}") }.join('・ ')
         flash.now[:error] = "不適切なコンテンツが含まれています：#{inappropriate_content}"
         render :new, status: :unprocessable_entity
-      else
+      elsif @post.valid?
         @post.save
         redirect_to posts_path, flash: { success: t('posts.create.success') }
+      else
+        flash.now[:error] = t('.fail')
+        render :new, status: :unprocessable_entity
       end
     rescue => e
       # エラー時の処理
       logger.error(e.message)
-      flash[:error] = 'Content analysis failed.'
-      render :new
+      flash.now[:error] = 'Content analysis failed.'
+      render :new, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -19,7 +19,9 @@ class PostsController < ApplicationController
       categories = result['moderationCategories'].to_a
       high_confidence = categories.any? { |category| category['confidence'] > 0.8 }
       if high_confidence
-        flash.now[:error] = t('.fail')
+        high_confidence_categories = categories.select { |category| category['confidence'] > 0.8 }
+        inappropriate_content = high_confidence_categories.map { |category| t("moderation_categories.#{category['name']}") }.join('・ ')
+        flash.now[:error] = "不適切なコンテンツが含まれています：#{inappropriate_content}"
         render :new, status: :unprocessable_entity
       else
         @post.save

--- a/app/services/content_moderation_service.rb
+++ b/app/services/content_moderation_service.rb
@@ -1,0 +1,40 @@
+
+require 'googleauth'
+
+class ContentModerationService
+  SCOPE = 'https://www.googleapis.com/auth/cloud-language'
+
+  def initialize(post)
+    @post = post
+    @credentials = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open('app/services/service_account.json'),
+      scope: SCOPE
+    )
+  end
+
+  def analyze
+    access_token = @credentials.fetch_access_token!['access_token']
+    url = 'https://language.googleapis.com/v1/documents:moderateText'
+    response = Faraday.post(url) do |req|
+      req.headers['Authorization'] = "Bearer #{access_token}"
+      req.headers['Content-Type'] = 'application/json; charset=utf-8'
+      req.body = {
+        document: {
+          type: 'PLAIN_TEXT',
+          content: @post
+        }
+      }.to_json
+    end
+
+    if response.success?
+      JSON.parse(response.body)
+    else
+      # ステータスコードによっては再試行するなどの処理を入れる
+      raise "API request failed with status: #{response.status}"
+    end
+  rescue Faraday::Error => e
+    raise "HTTP request failed: #{e.message}"
+  rescue JSON::ParserError => e
+    raise "JSON parsing failed: #{e.message}"
+  end
+end

--- a/config/locales/errors/ja.yml
+++ b/config/locales/errors/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  moderation_categories:
+    Toxic: '有害'
+    Insult: '侮辱'
+    Profanity: '暴力'
+    Derogatory: '侮辱'
+    Sexual: '性的'
+    Death, Harm & Tragedy: '死や害'
+    Violent: '冒とく'
+    Firearms & Weapons: '武器'
+    Public Safety: '安全'
+    Health: '人体への悪影響'
+    Religion & Belief: '宗教'
+    Illicit Drugs: '違法ドラッグ'
+    War & Conflict: '戦争'
+    Politics: '金融'
+    Finance: '政治'
+    Legal: '法律'

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe "Posts", type: :system do
   describe '新規投稿' do
     before do
       login(user)
+      find('button', text: 'POST').click
     end
 
     context '成功' do
       it 'COMPLETEチャレンジの投稿が作成できる' do
-        find('button', text: 'POST').click
         click_on 'COMPLETE'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: 'content'
@@ -30,7 +30,6 @@ RSpec.describe "Posts", type: :system do
       end
 
       it 'GIVE UPチャレンジの投稿が作成できる' do
-        find('button', text: 'POST').click
         click_on 'GIVE UP'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: 'content'
@@ -55,7 +54,6 @@ RSpec.describe "Posts", type: :system do
       # 上記のカラムのバリデーションはCOMPLETEチャレンジ・GIVE UPチャレンジともに同じ設定
 
       it '挑戦名未入力' do
-        find('button', text: 'POST').click
         click_on 'GIVE UP'
         fill_in 'post[title]', with: nil
         fill_in 'post[content]', with: 'content'
@@ -74,7 +72,6 @@ RSpec.describe "Posts", type: :system do
       end
 
       it '挑戦内容未入力' do
-        find('button', text: 'POST').click
         click_on 'COMPLETE'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: nil
@@ -92,7 +89,6 @@ RSpec.describe "Posts", type: :system do
       end
 
       it 'カテゴリー未選択' do
-        find('button', text: 'POST').click
         click_on 'COMPLETE'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: 'content'
@@ -108,7 +104,6 @@ RSpec.describe "Posts", type: :system do
 
       # GIVE UPチャレンジのみretryカラムにバリデーションを設定
       it 'retryカラム未選択' do
-        find('button', text: 'POST').click
         click_on 'GIVE UP'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: 'content'
@@ -125,7 +120,6 @@ RSpec.describe "Posts", type: :system do
       end
 
       it '画像アップロード枚数上限(4枚)を超えての投稿' do
-        find('button', text: 'POST').click
         click_on 'COMPLETE'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: nil
@@ -140,6 +134,21 @@ RSpec.describe "Posts", type: :system do
         click_on '投稿する'
         expect(page).to have_content('投稿に失敗しました')
         expect(page).to have_content('画像アップロードに添付できる枚数は最大4枚です')
+      end
+
+      it '有害な投稿内容を含むとNatural language APIにより投稿阻止' do
+        click_on 'COMPLETE'
+        fill_in 'post[title]', with: 'title'
+        fill_in 'post[content]', with: '死・犯罪・災害・戦争・暴力・薬物' # 挑戦内容に有害な単語を記載
+        fill_in 'post[record]', with: 'record'
+        fill_in 'post[impression_event]', with: 'implession_event'
+        fill_in 'post[lesson]', with: 'lesson'
+        # カテゴリーを選択(複数選択可。制限なし)
+        find("input[type='checkbox'][value='1']").check
+        # 画像をアップロード(最大4枚)
+        attach_file 'post[images][]', ["#{Rails.root}/spec/fixtures/files/crazy_1.png", "#{Rails.root}/spec/fixtures/files/default.png", "#{Rails.root}/spec/fixtures/files/nice_fight_1.png", "#{Rails.root}/spec/fixtures/files/stop_1.png"]
+        click_on '投稿する'
+        expect(page).to have_content('不適切なコンテンツが含まれています：死や害・ 冒とく・ 違法ドラッグ・ 戦争')
       end
     end
   end


### PR DESCRIPTION
- [ ] Google Cloud PlatfromのNatural language APIのテキスト管理機能をアプリに追加
- [ ] contentカラムにて不適切な内容が含まれており、16種類ある不適切なカテゴリーの内1カテゴリーでも信頼度スコアが0.8を超えると、不適切な投稿として投稿を拒否される
- [ ] エラーメッセージとして、その投稿にどのカテゴリーの内容が含まれているかを表示する
- [ ] 今までと同様に、投稿内容に不適切な内容が含まれていなくてもバリデーションエラーが含まれていると、投稿されない