### PR TITLE
N+1問題などの修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem 'bullet'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,9 @@ GEM
     bootsnap (1.17.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.1.6)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.39.2)
       addressable
       matrix
@@ -384,6 +387,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.16.0)
     version_gem (1.1.3)
     web-console (4.2.1)
       actionview (>= 6.0.0)
@@ -411,6 +415,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   bootsnap
+  bullet
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails (~> 1.3)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :find_post, only: [:edit, :update, :destroy]
 
   def index
-    @posts = Post.with_attached_images.includes({user: :profile}, :comments).order(created_at: :desc)
+    @posts = Post.includes(images_attachments: :blob, user: :profile).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -69,7 +69,7 @@ class PostsController < ApplicationController
                   .group('posts.id')
                   .order('likes_count DESC')
                   .limit(10)
-                  .includes(:user)
+                  .includes(:user, { user: :profile }, :categories)
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,7 @@ class PostsController < ApplicationController
   before_action :find_post, only: [:edit, :update, :destroy]
 
   def index
-    @posts = Post.with_attached_images.includes(:user, :categories).order(created_at: :desc)
+    @posts = Post.with_attached_images.includes({user: :profile}, :comments).order(created_at: :desc)
   end
 
   def new

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
-  belongs_to :post
+  belongs_to :post, counter_cache: true
 
   validates :body, presence: true
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,7 +3,7 @@
     <% @posts.each do |post| %>
     <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded">
       <% if post.images.attached? %>
-        <%= image_tag(post.images.first, style: "width: 390px; height: 300px; object-fit: cover;") %>
+        <%= image_tag(post.images.first.variant(resize_to_limit: [390, 300]).processed, style: "width: 390px; height: 300px; object-fit: cover;") %>
       <% elsif post.challenge_result == 'complete' %>
         <%= image_tag('complete.png', style: "width: 390px; height: 300px; object-fit: cover;") %>
       <% else %>
@@ -47,8 +47,11 @@
           <div class="pt-2">
             <%= render 'likes_count', { post: post } %>
           </div>
-          <div class="mt-1">
-            <%= render 'comments/count', { post: post } %>
+          <div class="flex items-center text-black ml-7 mt-1 mb-1">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-9 h-9">
+            <path fill-rule="evenodd" d="M12 2.25c-2.429 0-4.817.178-7.152.521C2.87 3.061 1.5 4.795 1.5 6.741v6.018c0 1.946 1.37 3.68 3.348 3.97.877.129 1.761.234 2.652.316V21a.75.75 0 0 0 1.28.53l4.184-4.183a.39.39 0 0 1 .266-.112c2.006-.05 3.982-.22 5.922-.506 1.978-.29 3.348-2.023 3.348-3.97V6.741c0-1.947-1.37-3.68-3.348-3.97A49.145 49.145 0 0 0 12 2.25ZM8.25 8.625a1.125 1.125 0 1 0 0 2.25 1.125 1.125 0 0 0 0-2.25Zm2.625 1.125a1.125 1.125 0 1 1 2.25 0 1.125 1.125 0 0 1-2.25 0Zm4.875-1.125a1.125 1.125 0 1 0 0 2.25 1.125 1.125 0 0 0 0-2.25Z" clip-rule="evenodd" />
+            </svg>
+            <div class="font-bold text-ml ml-1"><%= post.comments_count %></div>
           </div>
         </div>
       </div>

--- a/app/views/posts/ranking.html.erb
+++ b/app/views/posts/ranking.html.erb
@@ -58,7 +58,7 @@
                     <span class="mr-2 mt-2 text-black font-bold"><%= post.likes_count %></span>
                   </td>
                   <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-lg whitespace-nowrap px-3 pb-3 pt-10 text-center">
-                    <span class="mr-2 text-black"><%= render 'posts/category', { pos: post, categories: post.categories } %></span>
+                    <span class="mr-2 text-black"><%= render 'posts/category', { post: post, categories: post.categories } %></span>
                   </td>
                   <td class="border-t-0 px-6 align-middle border-l-0 border-r-0 text-lg whitespace-nowrap p-3 text-center">
                     <span class="mr-2 text-black"><%= post.created_at.strftime('%Y/%m/%d') %></span>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/db/migrate/20240129145401_add_comments_count_to_posts.rb
+++ b/db/migrate/20240129145401_add_comments_count_to_posts.rb
@@ -1,0 +1,6 @@
+class AddCommentsCountToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :comments_count, :integer, default: 0, null: false
+    Post.find_each { |post| Post.reset_counters(post.id, :comments) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_14_170442) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_29_145401) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_14_170442) do
     t.integer "retry"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "comments_count", default: 0, null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 

--- a/spec/system/comments_spec.rb
+++ b/spec/system/comments_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Comments", type: :system do
       click_on '投稿'
       expect(page).to have_selector('turbo-frame#count .font-bold', text: '3') # comment_post_Aとcomment_post_Bをlet!で定義したため、ユーザーAとBがすでに2件コメントしている状態だった
       visit posts_path
-      expect(page).to have_selector('turbo-frame#count .font-bold', text: '3')
+      expect(page).to have_selector('.font-bold', text: '3')
     end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Posts", type: :system do
     end
 
     context '成功' do
-      fit 'COMPLETEチャレンジの投稿が作成できる' do
+      it 'COMPLETEチャレンジの投稿が作成できる' do
         click_on 'COMPLETE'
         fill_in 'post[title]', with: 'title'
         fill_in 'post[content]', with: 'content'


### PR DESCRIPTION
概要
bulletにて各controllerを検査した結果、
posts#indexとposts#rankingにてN+1問題が発生してたため修正した

posts#indexのコメント数を効率よく取得するために、postsテーブルにcomments_countカラムを追加し
posts#indexのN+1問題を修正した。
またcategoryをincloudsに含めていたがcategoryの取得を削除していたことを失念していたため、
それに気づき削除した。

posts#rankingはprofileをincloudsに含めた。profileカラムのuser.avatarの取得のためN+1問題が発生していたため。