### PR TITLE
画像のリサイズ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "bootsnap", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 1.2"
 
 gem "dockerfile-rails", ">= 1.5", :group => :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,6 +435,7 @@ DEPENDENCIES
   faker
   faraday
   googleauth
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kaminari

--- a/app/controllers/concerns/image_processing_concern.rb
+++ b/app/controllers/concerns/image_processing_concern.rb
@@ -1,0 +1,15 @@
+module ImageProcessingConcern
+  extend ActiveSupport::Concern
+
+  def process_image(image, width: 800, height: 800)
+    return unless image
+
+    processed_image = ::ImageProcessing::Vips
+                        .source(image.tempfile)
+                        .resize_to_limit(width, height)
+                        .saver(quality: 80)
+                        .call
+
+    { io: File.open(processed_image.path), filename: image.original_filename, content_type: image.content_type }
+  end
+end

--- a/app/controllers/concerns/image_processing_concern.rb
+++ b/app/controllers/concerns/image_processing_concern.rb
@@ -4,12 +4,21 @@ module ImageProcessingConcern
   def process_image(image, width: 800, height: 800)
     return unless image
 
-    processed_image = ::ImageProcessing::Vips
-                        .source(image.tempfile)
-                        .resize_to_limit(width, height)
-                        .saver(quality: 80)
-                        .call
+    if image.content_type == 'image/heic'
+      processed_image = ::ImageProcessing::Vips
+                          .source(image.tempfile)
+                          .convert('jpg') # HEICをJPEGに変換
+                          .resize_to_limit(width, height)
+                          .saver(quality: 80)
+                          .call
+    else
+      processed_image = ::ImageProcessing::Vips
+                          .source(image.tempfile)
+                          .resize_to_limit(width, height)
+                          .saver(quality: 80)
+                          .call
+    end
 
-    { io: File.open(processed_image.path), filename: image.original_filename, content_type: image.content_type }
+    { io: File.open(processed_image.path), filename: "#{File.basename(image.original_filename, '.*')}.jpg", content_type: 'image/jpeg' }
   end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -42,7 +42,13 @@ class PostsController < ApplicationController
   def edit; end
 
   def update
-    if @post.update(post_params)
+    images = params[:post][:images].present? ? params[:post][:images].reject(&:blank?) : []
+    # 既存の画像を削除
+    @post.images.purge
+    # アップロードされた画像をリサイズしてアタッチ
+    attach_resized_images(images)
+
+    if @post.update(post_params.except(:images))
       redirect_to post_path(@post), flash: { success: t('posts.update.success') }
     else
       flash.now[:error] = t('.fail')
@@ -96,6 +102,6 @@ class PostsController < ApplicationController
   end
 
   def find_post
-    @post = current_user.posts.find(params[:id])
+    @post = current_user.posts.includes(images_attachments: [:blob]).find(params[:id])
   end
 end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,7 +1,16 @@
 class AvatarUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+
+  process :conditional_resize
+
+  def conditional_resize
+    image = MiniMagick::Image.open(file.path)
+    return if image[:width] <= 300 && image[:height] <= 300
+
+    resize_to_fill(300, 300)
+  end
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/uploaders/background_uploader.rb
+++ b/app/uploaders/background_uploader.rb
@@ -1,7 +1,16 @@
 class BackgroundUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
-  # include CarrierWave::MiniMagick
+  include CarrierWave::MiniMagick
+
+  process :conditional_resize
+
+  def conditional_resize
+    image = MiniMagick::Image.open(file.path)
+    return if image[:width] <= 2000 && image[:height] <= 500
+
+    resize_to_fit(2000, 500)
+  end
 
   # Choose what kind of storage to use for this uploader:
   storage :file

--- a/app/views/posts/_challenge_result.html.erb
+++ b/app/views/posts/_challenge_result.html.erb
@@ -1,5 +1,5 @@
 <% if post.challenge_result == 'complete' %>
-  <span class="bg-yellow-100 text-yellow-800 text-ml font-medium me-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-yellow-300 border border-yellow-300">COMPLETE</span>
+  <span class="bg-yellow-100 text-yellow-800 text-ml font-medium me-2 px-2.5 py-0.5 rounded border border-yellow-300">COMPLETE</span>
 <% else %>
-  <span class="bg-purple-100 text-purple-800 text-ml font-medium me-2 px-2.5 py-0.5 rounded dark:bg-gray-700 dark:text-purple-400 border border-purple-400">GIVE UP</span>
+  <span class="bg-purple-100 text-purple-800 text-ml font-medium me-2 px-2.5 py-0.5 rounded border border-purple-400">GIVE UP</span>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -38,7 +38,7 @@
         </div>
       </div>
 
-      <!-- content -->
+      <!-- content & image -->
       <div class="grid gap-4 grid-cols-1">
         <div class="flex flex-col p-4 relative items-center justify-center bg-slate-100 border border-gray-800 shadow-lg  rounded-2xl">
           <div class="w-full">
@@ -52,11 +52,10 @@
                 <p class="pb-1 text-gray-500">画像は最大4枚まで投稿できます</p>
                 <%= f.file_field :images, multiple: true, class:'text-black border-2 border-slate-400 rounded-full w-full md:w-1/2', data: { action: 'change->post-preview#previewPost', post_preview_target: 'input' } %>
                 <div id="post-preview" data-post-preview-target="imageBox" class="flex flex-wrap mt-3">
-
                   <% if post.images.attached? %>
                     <% post.images.each do |image| %>
                       <% if image.persisted? %>
-                        <%= image_tag image, class:'w-40 h-40 object-cover mr-2' %>
+                        <%= image_tag image.variant(resize_to_limit: [800, 800]), class: 'w-40 h-40 object-cover mr-2' %>
                       <% end %>
                     <% end %>
                   <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,7 +1,7 @@
 <!-- component -->
 <%= form_with model: post, local: true do |f| %>
 <%= f.hidden_field :challenge_result, value: post.challenge_result %>
-<div class="flex flex-col items-center justify-center min-h-screen" style="background-image:url('<%= image_path('post.jpeg') %>'); background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="flex flex-col items-center justify-center min-h-screen" style="background-image:url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <%= render 'shared/error_messages', object: f.object %>
   <div class="container m-4">
     <div class="max-w-3xl w-full mx-auto grid gap-4 grid-cols-1">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:py-20 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:py-20 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">
     <% @posts.each do |post| %>
     <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded">

--- a/app/views/posts/ranking.html.erb
+++ b/app/views/posts/ranking.html.erb
@@ -10,7 +10,7 @@
                 <h3 class="font-semibold text-lg text-black">
                   <% case index %>
                   <% when 0 %>
-                    <div class="text-black text-xl font-bold">Mr.CRAZY MAN</div>
+                    <div class="text-black text-xl font-bold">CRAZY MAN</div>
                   <% when 1 %>
                     <%= (index + 1) %>nd
                   <% when 2 %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,4 @@
-<div style="background-image:url('<%= image_path('post.jpeg') %>')">
+<div style="background-image:url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="flex justify-center items-center">
     <div class="bg-white text-white rounded-lg w-full mx-5 md:w-[40rem] m-10 lg:w-[70rem] p-10">
       <div class="flex justify-center">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -49,7 +49,7 @@
       <div class="grid grid-cols-1 md:grid-cols-4 col-span-2 gap-2" data-controller="image-viewer">
         <% @post.images.each do |image| %>
           <div class="overflow-hidden rounded-xl col-span-1 max-h-[14rem]">
-            <%= image_tag image, class: 'h-full w-full object-cover', data: { action: "click->image-viewer#expand" } %>
+            <%= image_tag image, class:'h-full w-full object-cover', data: { action: "click->image-viewer#expand" } %>
           </div>
         <% end %>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -46,13 +46,14 @@
         <%= render 'post', { post: @post } %>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-4 col-span-2 gap-2" data-controller="image-viewer">
+      <div class="flex flex-col items-center sm:flex-row sm:justify-center md:grid md:grid-cols-2 md:gap-4 lg:flex lg:flex-row lg:justify-center" data-controller="image-viewer">
         <% @post.images.each do |image| %>
-          <div class="overflow-hidden rounded-xl col-span-1 max-h-[14rem]">
-            <%= image_tag image, class:'h-full w-full object-cover', data: { action: "click->image-viewer#expand" } %>
+          <div class="overflow-hidden rounded-xl m-2">
+            <%= image_tag image, class:'h-60 w-60 object-cover', data: { action: "click->image-viewer#expand" } %>
           </div>
         <% end %>
       </div>
+
       <div class="flex items-center text-xs text-slate-500 mt-16">
         <%= @post.created_at.strftime('%Y/%m/%d %H:%M') %>
         <%= render 'comments/count', { post: @post, comment: @comment } %>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,6 @@
 <% if object.errors.any? %>
   <div id="error_messages" class="alert alert-danger">
-    <ul class="mb-2 text-red-300">
+    <ul class="mb-2 text-blue-500">
       <% object.errors.full_messages.each do |msg| %>
         <li><%= msg %></li>
       <% end %>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -89,7 +89,7 @@
               特にみんなからのCRAZY数が多い<br>
               上位10個の投稿を<br>
               ランキングとして表示するぞ<br>
-              目指せ‼️<span class="font-bold text-black text-xl"> Mr.CRZY MAN</span>
+              目指せ‼️<span class="font-bold text-black text-xl"> CRZY MAN</span>
             </p>
           </div>
         </div>
@@ -101,11 +101,11 @@
           <div class="lg:w-1/2 flex flex-col justify-center items-center">
             <h3 class="text-xl mb-5 font-bold">危険な投稿はやめてくれ</h3>
             <p class="leading-10 text-gray-500 text-center">
-              不快になるような挑戦の投稿は<br>
+              人々を不快にするような投稿は<br>
               <span class="font-bold text-red-500">絶対にやめてくれ</span><br>
-              投稿するとき不適切な言葉があると<br>
-              投稿できないから気をつけるんだ<br>
-              <span class="font-bold text-red-500">Badな投稿は削除するかもしれない</span>
+              危険な投稿や不適切な投稿があれば<br>
+              削除の対象になるぞ<br>
+              みんなで楽しく使ってくれ！！
             </p>
           </div>
         </div>
@@ -122,7 +122,7 @@
           <h3 class="text-xl mb-5 font-bold text-center">投稿</h3>
           <p class="text-center pb-2">
           COMPLETEかGIVEUPを選んで<br>
-          投稿しれくれ
+          投稿してくれ
           </p>
           <%= image_tag 'tops/post.png', class:'rounded-md h-48 max-h-48 w-full' %>
         </div>
@@ -139,8 +139,8 @@
         <div class="p-5 bg-slate-300 sm:me-5 sm:mb-10 mb-5 rounded-md hover:shadow-md">
           <h3 class="text-xl mb-5 font-bold text-center">いいね</h3>
           <p class="text-center pb-2">
-          COMPLETEかGIVEUPかで<br>
-          デザインが変わるぞ
+          気に入った挑戦があれば<br>
+          どんどんいいねしてくれ
           </p>
           <%= image_tag 'tops/likes.png', class:'rounded-md h-48 max-h-48 w-full' %>
         </div>
@@ -158,7 +158,7 @@
           <h3 class="text-xl mb-5 font-bold text-center">ランキング</h3>
           <p class="text-center pb-2">
           COMPLETEチャレンジで<br>
-          目指せ！Mr.CRAZY MAN！
+          目指せ！CRAZY MAN！
           </p>
           <%= image_tag 'tops/ranking.png', class:'rounded-md h-48 max-h-48 w-full' %>
         </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <!-- component -->
-<div class="flex h-screen w-full items-center justify-center bg-gray-900 bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="flex h-screen w-full items-center justify-center bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="rounded-xl bg-gray-800 bg-opacity-50 px-16 py-10 shadow-lg backdrop-blur-md max-sm:px-8">
     <div class="text-white">
       <div class="flex flex-col items-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <!-- component -->
-<div class="flex w-full items-center justify-center bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="flex w-full items-center justify-center bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="rounded-xl bg-gray-800 bg-opacity-50 px-16 my-10 shadow-lg backdrop-blur-md max-sm:px-8">
     <div class="text-white">
       <div class="flex flex-col items-center">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
+  # 画像の編集はlibvipsを使用
+  config.active_storage.variant_processor = :vips
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :amazon
 
+  # 画像の編集はlibvipsを使用
+  config.active_storage.variant_processor = :vips
+
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil
   # config.action_cable.url = "wss://example.com/cable"


### PR DESCRIPTION
概要
投稿内容に関連する画像の投稿時、オリジナル画像をそのまま保存すると、表示の際にバイト数の高い画像だと
メモリ逼迫に繋がる可能性があるため、libvipsを使用し保存時に画像をリサイズして保存するよう実装した。
またプロフィールのアバターと背景画像も同様にMinimagickを利用し画像をリサイズして保存すうよう実装した。