### PR TITLE
開発環境でのみhttps化適用を図るロジックの追加

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -25,10 +25,12 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 # port ENV.fetch("PORT") { 3000 }
 
-ssl_bind 'localhost', '3000', {
-  key: 'config/certs/localhost-key.pem',
-  cert: 'config/certs/localhost.pem'
-}
+if ENV.fetch("RAILS_ENV", "development") == "development"
+  ssl_bind 'localhost', '3000', {
+    key: 'config/certs/localhost-key.pem',
+    cert: 'config/certs/localhost.pem'
+  }
+end
 
 # Specifies the `environment` that Puma will run in.
 environment ENV.fetch("RAILS_ENV") { "development" }

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users", type: :system do
     end
 
     context '成功' do
-      it 'ユーザーの新規登録ができる' do
+      fit 'ユーザーの新規登録ができる' do
         fill_in 'user[username]', with: 'test01'
         fill_in 'user[email]', with: 'test01@example.com'
         fill_in 'user[password]', with: 'Password01'


### PR DESCRIPTION
herokuにて下記のエラーが発生
```
Key file 'config/certs/localhost-key.pem' does not exist (ArgumentError)
```

これはpuma.rbにてLINEログインを導入する際に、開発環境でのhttps化を適用するコードを記載していたが
本番環境にも適用しようといてたエラーであると思われるため、開発環境でのみ適用するようロジックを記載し修正した。