### PR TITLE
puma.rbにてhttps関連の記載修正

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,9 +23,11 @@ end
 worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-# port ENV.fetch("PORT") { 3000 }
-
-if ENV.fetch("RAILS_ENV", "development") == "development"
+if ENV.fetch("RAILS_ENV", "development") == "production"
+  # 本番環境でのみ実行される設定
+  port ENV.fetch("PORT") { 3000 }
+else
+  # 開発環境（またはテスト環境）でのみ実行される設定
   ssl_bind 'localhost', '3000', {
     key: 'config/certs/localhost-key.pem',
     cert: 'config/certs/localhost.pem'

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Users", type: :system do
     end
 
     context '成功' do
-      fit 'ユーザーの新規登録ができる' do
+      it 'ユーザーの新規登録ができる' do
         fill_in 'user[username]', with: 'test01'
         fill_in 'user[email]', with: 'test01@example.com'
         fill_in 'user[password]', with: 'Password01'


### PR DESCRIPTION
```
port ENV.fetch("PORT") { 3000 }

ssl_bind 'localhost', '3000', {
    key: 'config/certs/localhost-key.pem',
    cert: 'config/certs/localhost.pem'
  }
```
`port ENV.fetch("PORT") { 3000 }`部分をコメントアウトしてたためherokuでアプリが表示されなかったため
コメントアウトを外すと、htttpとhttpsが競合して開発環境でサーバーが起動しなかった。

なので、環境ごとに使用するものを分岐して競合を解決した。