### PR TITLE
検索機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "aws-sdk-s3"
 # ページネーション
 gem 'kaminari'
 
+# 検索機能
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,10 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.6.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.3)
@@ -480,6 +484,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.1)
   rails-i18n (~> 7.0.0)
+  ransack
   rspec-rails
   rubocop
   rubocop-checkstyle_formatter

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,7 +5,14 @@ class PostsController < ApplicationController
   before_action :find_post, only: %i[edit update destroy]
 
   def index
-    @posts = Post.includes(images_attachments: :blob, user: :profile).order(created_at: :desc).page(params[:page]).per(16)
+    @q = Post.ransack(params[:q])
+    @posts = @q.result.includes(images_attachments: :blob, user: :profile)
+                .order(created_at: :desc)
+                .page(params[:page]).per(16)
+
+    if params[:category_ids].present?
+      @posts = @posts.joins(:categories).where(categories: { id: params[:category_ids] })
+    end
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,7 +10,7 @@ class PostsController < ApplicationController
                 .order(created_at: :desc)
                 .page(params[:page]).per(16)
 
-    if params[:category_ids_in].present?
+    if params[:category_ids_in].present? && Category.exists?(id: params[:category_ids_in])
       @posts = @posts.joins(:categories).where(categories: { id: params[:category_ids_in] })
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,14 @@ class PostsController < ApplicationController
   before_action :find_post, only: %i[edit update destroy]
 
   def index
+    [:q, :category_ids_in].each do |key|
+      if params[key].present?
+        session[key] = params[key]
+      elsif session[key].present?
+        params[key] = session[key]
+      end
+    end
+
     @q = Post.ransack(params[:q])
     @posts = @q.result.includes(images_attachments: :blob, user: :profile)
                 .order(created_at: :desc)
@@ -71,6 +79,12 @@ class PostsController < ApplicationController
 
   def ranking
     @posts = Post.ranking
+  end
+
+  def reset_search
+    session.delete(:q)
+    session.delete(:category_ids_in)
+    redirect_to posts_path
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,8 +10,8 @@ class PostsController < ApplicationController
                 .order(created_at: :desc)
                 .page(params[:page]).per(16)
 
-    if params[:category_ids].present?
-      @posts = @posts.joins(:categories).where(categories: { id: params[:category_ids] })
+    if params[:category_ids_in].present?
+      @posts = @posts.joins(:categories).where(categories: { id: params[:category_ids_in] })
     end
   end
 

--- a/app/javascript/controllers/dropdown_multiselect_controller.js
+++ b/app/javascript/controllers/dropdown_multiselect_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="dropdown-multiselect"
+export default class extends Controller {
+  static targets = ["dropdown", "hiddenField", "dropdownMenu", "selectedItems"]
+
+  connect() {
+    console.log("DropdownMultiSelect controller connected");
+    this.selectedValues = [];
+  }
+
+  toggleDropdownMenu() {
+    this.dropdownMenuTarget.classList.toggle('hidden');
+  }
+
+  select(event) {
+    event.preventDefault();
+    const name = event.target.innerText;
+    const value = event.target.dataset.value;
+
+    // 既に選択されている項目をチェック
+    if (!this.selectedValues.includes(value)) {
+      this.selectedValues.push(value);
+
+      // 選択された項目を表示エリアに追加
+      const selectedItem = document.createElement("span");
+      selectedItem.textContent = name;
+      selectedItem.classList.add("selected-item", "bg-gray-200", "rounded-full", "px-2", "py-1", "text-sm", "mr-2");
+      this.selectedItemsTarget.appendChild(selectedItem);
+
+      // 隠しフィールドに選択されたカテゴリーIDを格納
+      this.hiddenFieldTarget.value = this.selectedValues.join(',');
+    }
+
+    // ドロップダウンメニューを閉じる
+    this.toggleDropdownMenu();
+  }
+}

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -45,6 +45,10 @@ class Post < ApplicationRecord
     end
   end
 
+  def self.ransackable_attributes(auth_object = nil)
+    %w[challenge_result category_ids]
+  end
+
   private
 
   def image_count_within_limit

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -46,7 +46,7 @@ class Post < ApplicationRecord
   end
 
   def self.ransackable_attributes(auth_object = nil)
-    %w[challenge_result category_ids]
+    %w[challenge_result]
   end
 
   private

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,20 +1,23 @@
-<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex items-center relative' } do |f| %>
+<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex flex-row relative' } do |f| %>
 
   <div class="form-group mb-1 flex flex-col mr-8">
-    <%= f.label :challenge_result_eq, "Challenge Result", class: 'text-white mb-1' %>
+    <%= f.label :challenge_result_eq, "Challenge Result", class: 'text-white' %>
     <%= f.select :challenge_result_eq, options_for_select(Post.challenge_results.map{ |k, v| [k.humanize, v] }, @q.challenge_result_eq), { include_blank: 'Select' }, { class: 'bg-white p-2 rounded cursor-pointer w-full' } %>
   </div>
 
   <div class="form-group mb-1" data-controller="dropdown-multiselect">
-    <label for="category" class="text-white mb-1">Category</label>
-    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer w-48">
+    <label for="category" class="text-white">Category</label>
+    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer w-48 flex items-center">
       Choose category
+      <svg class="h-5 w-5 ml-2 ml-7 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+      </svg>
     </div>
     <div data-target="dropdown-multiselect.selectedItems" class="selected-items flex flex-wrap mt-1 border-1 border-blue-400"></div>
     <input type="hidden" name="category_ids_in[]" data-target="dropdown-multiselect.hiddenField">
-    <div class="dropdown-menu hidden bg-white absolute z-10" data-target="dropdown-multiselect.dropdownMenu">
+    <div class="dropdown-menu hidden bg-gray-300 absolute z-10 rounded" data-target="dropdown-multiselect.dropdownMenu">
       <% Category.all.each do |c| %>
-        <a href="#" class="dropdown-item block p-2 hover:bg-gray-100" data-value="<%= c.id %>" data-action="click->dropdown-multiselect#select"><%= c.name %></a>
+        <a href="#" class="dropdown-item block p-2 hover:bg-blue-500 rounded" data-value="<%= c.id %>" data-action="click->dropdown-multiselect#select"><%= c.name %></a>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,0 +1,25 @@
+<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex items-center relative' } do |f| %>
+
+  <div class="form-group mb-1 flex flex-col mr-8">
+    <%= f.label :challenge_result_eq, "Challenge Result", class: 'text-white mb-1' %>
+    <%= f.select :challenge_result_eq, options_for_select(Post.challenge_results.map{ |k, v| [k.humanize, v] }, @q.challenge_result_eq), { include_blank: 'Select' }, { class: 'bg-white p-2 rounded cursor-pointer w-full' } %>
+  </div>
+
+  <div class="form-group mb-1" data-controller="dropdown-multiselect">
+    <label for="category" class="text-white mb-1">Category</label>
+    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer w-48">
+      Choose category
+    </div>
+    <div data-target="dropdown-multiselect.selectedItems" class="selected-items flex flex-wrap mt-1 border-1 border-blue-400"></div>
+    <input type="hidden" name="category_ids_in[]" data-target="dropdown-multiselect.hiddenField">
+    <div class="dropdown-menu hidden bg-white absolute z-10" data-target="dropdown-multiselect.dropdownMenu">
+      <% Category.all.each do |c| %>
+        <a href="#" class="dropdown-item block p-2 hover:bg-gray-100" data-value="<%= c.id %>" data-action="click->dropdown-multiselect#select"><%= c.name %></a>
+      <% end %>
+    </div>
+  </div>
+
+  <div class="flex flex-col absolute left-96 top-6">
+    <%= f.submit "Search", class: 'btn btn-primary rounded bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white p-2 font-semibold' %>
+  </div>
+<% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -22,6 +22,19 @@
   </div>
 
   <div class="flex flex-col mt-3 md:absolute md:left-96 md:top-3">
-    <%= f.submit t('posts.index.search_form.search'), class: 'btn btn-primary rounded bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white py-2 px-5 font-semibold' %>
+    <button type="submit" class="btn btn-primary rounded bg-teal-500 hover:bg-teal-600 text-white py-2 px-5 font-semibold flex items-center justify-center">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 mr-2">
+        <path fill-rule="evenodd" d="M10.5 3.75a6.75 6.75 0 1 0 0 13.5 6.75 6.75 0 0 0 0-13.5ZM2.25 10.5a8.25 8.25 0 1 1 14.59 5.28l4.69 4.69a.75.75 0 1 1-1.06 1.06l-4.69-4.69A8.25 8.25 0 0 1 2.25 10.5Z" clip-rule="evenodd" />
+      </svg>
+      <%= t('posts.index.search_form.search') %>
+    </button>
   </div>
 <% end %>
+
+<%= link_to reset_search_posts_path, method: :get, class: 'flex justify-center items-center p-2 mt-4 rounded bg-red-600 hover:bg-red-700 text-white font-bold md:absolute md:left-[34rem] md:top-[6.7rem] w-full md:w-48' do %>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 mr-1">
+    <path fill-rule="evenodd" d="M2.515 10.674a1.875 1.875 0 0 0 0 2.652L8.89 19.7c.352.351.829.549 1.326.549H19.5a3 3 0 0 0 3-3V6.75a3 3 0 0 0-3-3h-9.284c-.497 0-.974.198-1.326.55l-6.375 6.374ZM12.53 9.22a.75.75 0 1 0-1.06 1.06L13.19 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06l1.72-1.72 1.72 1.72a.75.75 0 1 0 1.06-1.06L15.31 12l1.72-1.72a.75.75 0 1 0-1.06-1.06l-1.72 1.72-1.72-1.72Z" clip-rule="evenodd" />
+  </svg>
+  検索条件をリセット
+<% end %>
+

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,14 +1,14 @@
 <%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex flex-col md:flex-row relative' } do |f| %>
   <div class="form-group mb-1 flex flex-col mr-8 w-full md:w-32">
-    <%= f.label :challenge_result_eq, "Challenge Result", class: 'text-white' %>
-    <%= f.select :challenge_result_eq, options_for_select(Post.challenge_results.map{ |k, v| [k.humanize, v] }, @q.challenge_result_eq), { include_blank: 'Select' }, { class: 'bg-white p-2 rounded cursor-pointer w-full' } %>
+    <%= f.label :challenge_result, t('posts.index.search_form.challenge_result'), "Challenge Result", class: 'text-white' %>
+    <%= f.select :challenge_result_eq, options_for_select(Post.challenge_results.map{ |k, v| [k.humanize, v] }, @q.challenge_result_eq), { include_blank: '---' }, { class: 'bg-white p-2 rounded cursor-pointer w-full' } %>
   </div>
 
   <div class="form-group mb-1" data-controller="dropdown-multiselect">
-    <label for="category" class="text-white">Category</label>
+    <label for="category" class="text-white"><%= t('posts.index.search_form.category') %></label>
     <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer md:w-48 flex items-center border-solid border border-slate-500">
-      Choose category
-      <svg class="h-5 w-5 ml-44 md:ml-7 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <%= t('posts.index.search_form.choose_category') %>
+      <svg class="h-5 w-5 ml-[13.8rem] md:ml-[4.5rem] text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
       </svg>
     </div>
@@ -22,6 +22,6 @@
   </div>
 
   <div class="flex flex-col mt-3 md:absolute md:left-96 md:top-3">
-    <%= f.submit "Search", class: 'btn btn-primary rounded bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white p-2 font-semibold' %>
+    <%= f.submit t('posts.index.search_form.search'), class: 'btn btn-primary rounded bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white py-2 px-5 font-semibold' %>
   </div>
 <% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,15 +1,14 @@
-<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex flex-row relative' } do |f| %>
-
-  <div class="form-group mb-1 flex flex-col mr-8">
+<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'form-inline flex flex-col md:flex-row relative' } do |f| %>
+  <div class="form-group mb-1 flex flex-col mr-8 w-full md:w-32">
     <%= f.label :challenge_result_eq, "Challenge Result", class: 'text-white' %>
     <%= f.select :challenge_result_eq, options_for_select(Post.challenge_results.map{ |k, v| [k.humanize, v] }, @q.challenge_result_eq), { include_blank: 'Select' }, { class: 'bg-white p-2 rounded cursor-pointer w-full' } %>
   </div>
 
   <div class="form-group mb-1" data-controller="dropdown-multiselect">
     <label for="category" class="text-white">Category</label>
-    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer w-48 flex items-center">
+    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer md:w-48 flex items-center border-solid border border-slate-500">
       Choose category
-      <svg class="h-5 w-5 ml-2 ml-7 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="h-5 w-5 ml-44 md:ml-7 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
       </svg>
     </div>
@@ -22,7 +21,7 @@
     </div>
   </div>
 
-  <div class="flex flex-col absolute left-96 top-6">
+  <div class="flex flex-col mt-3 md:absolute md:left-96 md:top-3">
     <%= f.submit "Search", class: 'btn btn-primary rounded bg-gradient-to-r from-green-400 to-blue-500 hover:from-pink-500 hover:to-yellow-500 text-white p-2 font-semibold' %>
   </div>
 <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-8 md:pb-10 md:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="px-4 py-5 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-8 md:pb-10 md:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="mb-10">
     <%= render 'search_form' %>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,5 +1,5 @@
 <div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:pb-10 lg:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
-  <div class="mb-5">
+  <div class="mb-10">
     <%= render 'search_form' %>
   </div>
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:pb-10 lg:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-8 md:pb-10 md:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="mb-10">
     <%= render 'search_form' %>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,7 @@
-<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:py-20 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:pb-10 lg:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+  <div class="mb-5">
+    <%= render 'search_form' %>
+  </div>
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">
     <% @posts.each do |post| %>
     <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded relative">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 <div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-24 lg:px-8 lg:py-20 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">
     <% @posts.each do |post| %>
-    <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded">
+    <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded relative">
       <%= image_tag(post.display_image, style: "width: 390px; height: 300px; object-fit: cover;") %>
       <div class="py-5">
         <p class="mb-2 text-xs font-semibold text-gray-600 uppercase"><%= post.created_at.strftime('%Y/%m/%d %H:%M') %></p>
@@ -19,27 +19,25 @@
         </div>
 
         <div class="nline-block my-3 text-black transition-colors duration-200 hover:text-deep-purple-accent-700">
-        <p class="text-xl leading-5"><%= truncate(post.title, length: 28) %></p>
+          <p class="text-xl leading-5"><%= truncate(post.title, length: 28) %></p>
         </div>
         <p class="mb-4 text-gray-700"><%= truncate(post.content, length: 51) %></p>
 
         <div class="text-center my-4">
-          <%= link_to 'Read more', post_path(post), class: 'inline-flex items-center font-semibold transition-colors duration-200 text-blue-700 hover:text-deep-blue-800 no-underline hover:underline' %>
+          <%= link_to 'Read more', post_path(post), class: 'inline-flex items-center font-semibold transition-colors duration-200 text-blue-700 hover:text-blue-400 underline' %>
         </div>
 
-        <div class="flex space-x-2">
-          <div class="">
-            <% case post.challenge_result %>
-            <% when 'complete' %>
-              <%= image_tag 'likes/crazy_1.png', class: 'h-10 w-10' %>
+        <div class="flex space-x-2 absolute bottom-5 left-5 right-3">
+          <% case post.challenge_result %>
+          <% when 'complete' %>
+            <%= image_tag 'likes/crazy_1.png', class: 'h-10 w-10' %>
+          <% else %>
+            <% if post.retry == 'try' %>
+              <%= image_tag 'likes/fight_1.png', class: 'h-10 w-10' %>
             <% else %>
-              <% if post.retry == 'try' %>
-                <%= image_tag 'likes/fight_1.png', class: 'h-10 w-10' %>
-              <% else %>
-                <%= image_tag 'likes/nice_fight_1.png', class: 'h-10 w-10' %>
-              <% end %>
+              <%= image_tag 'likes/nice_fight_1.png', class: 'h-10 w-10' %>
             <% end %>
-          </div>
+          <% end %>
           <div class="pt-2 font-bold text-ml ml-1">
             <%= post.likes_count %>
           </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -9,10 +9,10 @@
         <nav aria-label="Global" class="hidden md:block">
           <ul class="flex items-center gap-6 text-xl">
             <li>
-              <%= link_to 'RANKING', ranking_posts_path, class:'text-black transition hover:text-gray-500/75 pl-6' %>
+              <%= link_to 'RANKING', ranking_posts_path, class:'text-black transition hover:text-white pl-6' %>
             </li>
             <li>
-              <%= link_to 'POST LIST', posts_path, class:'text-black transition hover:text-gray-500/75 pl-6' %>
+              <%= link_to 'POST LIST', posts_path, class:'text-black transition hover:text-white pl-6' %>
             </li>
           </ul>
         </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,22 +9,22 @@
       <nav aria-label="Global" class="hidden md:block">
         <ul class="flex items-center gap-6 text-xl">
           <li>
-            <%= link_to 'TOP', root_path, class:'text-black transition hover:text-gray-500/75 pl-6' %>
+            <%= link_to 'TOP', root_path, class:'text-black transition hover:text-white pl-6' %>
           </li>
           <li>
-            <%= link_to 'POST LIST', posts_path, class:'text-black transition hover:text-gray-500/75 pl-6' %>
+            <%= link_to 'POST LIST', posts_path, class:'text-black transition hover:text-white pl-6' %>
           </li>
           <li>
-            <%= link_to 'RANKING', ranking_posts_path, class:'text-black transition hover:text-gray-500/75 pl-6' %>
+            <%= link_to 'RANKING', ranking_posts_path, class:'text-black transition hover:text-white pl-6' %>
           </li>
           <li data-controller="dropdown" class="z-20">
-            <button type="button" class="text-black transition hover:text-gray-500/75 pl-6" data-action="click->dropdown#toggleMenu">POST</button>
-            <ul class="hidden absolute w-48 bg-white shadow-md mt-2 rounded-md" data-dropdown-target="menu">
+            <button type="button" class="text-black transition hover:text-white pl-6" data-action="click->dropdown#toggleMenu">POST</button>
+            <ul class="hidden absolute w-48 bg-white shadow-md mt-2 rounded-md py-1" data-dropdown-target="menu">
               <li>
-                <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-100' %>
+                <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
               </li>
               <li>
-                <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-100' %>
+                <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
               </li>
             </ul>
           </li>
@@ -40,8 +40,8 @@
       </button>
 
       <div class="absolute right-0 z-10 w-48 py-1 mt-2 origin-top-right bg-white rounded-md shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none hidden top-full" data-target="dropdown.menu" aria-orientation="vertical" aria-labelledby="user-menu-button" tabindex="-1">
-        <%= link_to 'PROFILE', profile_path, class:'block px-4 py-2 text-sm text-slate-950', id:'user-menu-item-0' %>
-        <%= link_to 'LOGOUT', logout_path, class:'block px-4 py-2 text-sm text-slate-950', id:'user-menu-item-2', data: { turbo_method: :delete } %>
+        <%= link_to 'PROFILE', profile_path, class:'block px-4 py-2 text-sm text-slate-950 hover:bg-gray-300', id:'user-menu-item-0' %>
+        <%= link_to 'LOGOUT', logout_path, class:'block px-4 py-2 text-sm text-slate-950 hover:bg-gray-300', id:'user-menu-item-2', data: { turbo_method: :delete } %>
       </div>
     </div>
   </div>
@@ -63,10 +63,10 @@
           <button type="button" class="text-white transition" data-action="click->dropdown#toggleMenu">POST</button>
           <ul class="hidden absolute w-48 bg-white shadow-md mt-2 rounded-md" data-dropdown-target="menu">
             <li>
-              <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-100' %>
+              <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
             </li>
             <li>
-              <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-100' %>
+              <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
             </li>
           </ul>
         </li>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -9,8 +9,8 @@
               <p class="text-white text-sm">クレイジーな挑戦に挑んだ君へ</p>
             </div>
             <div class="flex flex-col gap-3 mt-3">
-              <%= link_to 'はじめる', new_user_path, class:'text-white bg-black mx-auto w-32 text-center rounded-md p-2 border border-1 border-red-500 hover:bg-red-700' %>
-              <%= link_to 'ログインはこちら', login_path, class:'text-gray-400 text-sm hover:text-white' %>
+              <%= link_to 'はじめる', login_path, class:'text-white bg-black mx-auto w-32 text-center rounded-md p-2 border border-1 border-red-500 hover:bg-red-700' %>
+              <%= link_to '会員登録はこちら', new_user_path, class:'text-gray-400 text-sm hover:text-white' %>
             </div>
         </div>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,6 +29,12 @@ ja:
       success: 'プロフィールを更新しました'
       fail: 'プロフィール作成に失敗しました'
   posts:
+    index:
+      search_form:
+        challenge_result: '挑戦結果'
+        category: 'カテゴリー'
+        search: '検索'
+        choose_category: '複数選択可'
     create:
       post: '投稿する'
       success: '新規投稿されました'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     resources :comments, only: %i[create edit update destroy]
     collection do
       get 'ranking'
+      get 'reset_search'
     end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -255,4 +255,62 @@ RSpec.describe "Posts", type: :system do
       expect(page).to have_no_content(give_up_post.title)
     end
   end
+
+  describe '検索' do
+    before do
+      login(user)
+    end
+
+    context '挑戦結果のみの検索ができる' do
+      # 現在let!定義によりCOPLETEとGIVE_UP投稿がある状態
+
+      it 'COMPLETE検索' do
+        select 'Complete', from: 'q_challenge_result_eq'
+        click_button '検索'
+        expect(page).to have_content('COMPLETE')
+      end
+
+      it 'GIVE UP検索' do
+        select 'Give up', from: 'q_challenge_result_eq'
+        click_button '検索'
+        expect(page).to have_content('GIVE UP')
+      end
+    end
+
+    context 'カテゴリーのみの検索' do
+      # let!定義の投稿は冒険・探究カテゴリーを選択してる
+
+      it 'カテゴリーの検索結果が表示される' do
+        find('div[data-target="dropdown-multiselect.dropdown"]').click
+        find('a', text: '冒険・探究').click
+        click_button '検索'
+        post_id = give_up_post.id
+        link = "/posts/#{post_id}"
+        expect(page).to have_selector("a[href='#{link}']")
+        find("a[href='#{link}']").click
+        link = "/posts/#{post_id}/likes"
+        expect(page).to have_content('冒険・探究')
+      end
+
+      it '存在しないカテゴリーだと検索結果が空になる' do
+        find('div[data-target="dropdown-multiselect.dropdown"]').click
+        find('a', text: 'スポーツ').click
+        click_button '検索'
+        expect(page).to have_content('Read more', count: 0)
+      end
+    end
+
+    it '挑戦結果とカテゴリーの両方の検索ができる' do
+      select 'Complete', from: 'q_challenge_result_eq'
+      find('div[data-target="dropdown-multiselect.dropdown"]').click
+      find('a', text: '冒険・探究').click
+      click_button '検索'
+      post_id = complete_post.id
+      link = "/posts/#{post_id}"
+      expect(page).to have_selector("a[href='#{link}']")
+      find("a[href='#{link}']").click
+      expect(page).to have_content('COMPLETE')
+      expect(page).to have_content('冒険・探究')
+    end
+  end
 end


### PR DESCRIPTION
概要
MVPレビューにて以下が挙げられた
1.  投稿一覧のいいね・コメント位置の統一
2.  投稿一覧のRead moreの強調
3.  挑戦結果(completeとgive up)のソート機能

1と2はtailwindcssにより修正した。

3はソート機能ではなく、検索機能(ransack)によるソート機能を実現させた。
またカテゴリーも検索できるようにした。
ページネーションにて次のページへ遷移した際に検索条件がリセットされ、検索条件に関係のない投稿が表示されるため
ページ遷移時はURLの情報をセッションに保存させ、次のページでも検索条件に合った投稿を表示させるようにした。
セッション情報を削除して検索条件を簡単に解除できるよう、リセットボタンも配置した。

#90  
Close #95 #94 
