### PR TITLE
メール送信時のバグ修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -97,4 +97,7 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+
+  # パスワードリセット時のメール送信する際のホスト情報の設定
+  config.action_mailer.default_url_options = { host: 'fierce-plateau-48229-09e6d0eb36ec.herokuapp.com', protocol: 'https' }
 end


### PR DESCRIPTION
パスワードリセット時のメールアドレスを入力し、リセット用のリンクを要求する場面でエラーが発生。
production環境のメール送信に関するホスト情報の設定ができてなかったため修正。

#88 