### PR TITLE
Natural Language APIを全カラム及びupdateアクションへ導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ give upした挑戦は達成できてないため、ランキング化はしま�
 https://www.figma.com/file/bYm3gAgfyFwbDCRwKpCDT3/crazy_challenge_record?type=design&node-id=0%3A1&mode=design&t=Y6dHQ2dFwSjpMyqN-1
 
 ### ER図
-[![Image from Gyazo](https://i.gyazo.com/9a629fd3b14e1ad5d025ab26bf1c18bf.png)](https://gyazo.com/9a629fd3b14e1ad5d025ab26bf1c18bf)
+[![Image from Gyazo](https://i.gyazo.com/6f36486c5bc8b9ba6933bde53ccb55a0.png)](https://gyazo.com/6f36486c5bc8b9ba6933bde53ccb55a0)

--- a/app/controllers/concerns/image_processing_concern.rb
+++ b/app/controllers/concerns/image_processing_concern.rb
@@ -2,7 +2,6 @@ module ImageProcessingConcern
   extend ActiveSupport::Concern
 
   def process_image(image, width: 800, height: 800)
-    return unless image
 
     if image.content_type == 'image/heic'
       processed_image = ::ImageProcessing::Vips

--- a/app/controllers/concerns/post_moderation_concern.rb
+++ b/app/controllers/concerns/post_moderation_concern.rb
@@ -1,6 +1,23 @@
 module PostModerationConcern
   extend ActiveSupport::Concern
 
+  def post_invalid
+    if @post.invalid?
+      flash.now[:error] = t('.fail')
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def content_moderated(post)
+    full_text = generate_full_text(post)
+    if content_moderated?(full_text)
+      flash.now[:error] = moderation_message
+      render :new, status: :unprocessable_entity
+      return true
+    end
+    false
+  end
+
   def generate_full_text(post)
     [
       post.title,

--- a/app/controllers/concerns/post_moderation_concern.rb
+++ b/app/controllers/concerns/post_moderation_concern.rb
@@ -1,0 +1,22 @@
+module PostModerationConcern
+  extend ActiveSupport::Concern
+
+  def content_moderated?(content)
+    moderation_service = ContentModerationService.new(content)
+    result = moderation_service.analyze
+    categories = result['moderationCategories'].to_a
+    @high_confidence_categories = categories.select { |category| category['confidence'] > 0.8 }
+    @high_confidence_categories.any?
+  end
+
+  def moderation_message
+    inappropriate_content = @high_confidence_categories.map { |category| t("moderation_categories.#{category['name']}") }.join('・ ')
+    "不適切なコンテンツが含まれています：#{inappropriate_content}"
+  end
+
+  def handle_content_analysis_error(e)
+    logger.error(e.message)
+    flash.now[:error] = 'Content analysis failed.'
+    render :new, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/concerns/post_moderation_concern.rb
+++ b/app/controllers/concerns/post_moderation_concern.rb
@@ -1,8 +1,18 @@
 module PostModerationConcern
   extend ActiveSupport::Concern
 
-  def content_moderated?(content)
-    moderation_service = ContentModerationService.new(content)
+  def generate_full_text(post)
+    [
+      post.title,
+      post.content,
+      post.record,
+      post.impression_event,
+      post.lesson
+    ].join("\n")
+  end
+
+  def content_moderated?(full_text)
+    moderation_service = ContentModerationService.new(full_text)
     result = moderation_service.analyze
     categories = result['moderationCategories'].to_a
     @high_confidence_categories = categories.select { |category| category['confidence'] > 0.8 }

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,9 +30,7 @@ class PostsController < ApplicationController
     @post.images.purge # オリジナル画像とリサイズ画像の両方を保存させないため
     attach_resized_images(params[:post][:images].reject(&:blank?)) if params[:post][:images].reject(&:blank?).present?
 
-    if @post.save!
-      redirect_to posts_path, flash: { success: t('posts.create.success') }
-    end
+    redirect_to posts_path, flash: { success: t('posts.create.success') } if @post.save!
   rescue => e
     handle_content_analysis_error(e)
   end
@@ -50,13 +48,12 @@ class PostsController < ApplicationController
     return if post_invalid
     return if content_moderated(@post)
 
+    @post.reload
     @post.images.purge
     images = params[:post][:images].present? ? params[:post][:images].reject(&:blank?) : []
     attach_resized_images(images)
 
-    if @post.save! # 上記を満たせば保存
-      redirect_to post_path(@post), flash: { success: t('posts.update.success') }
-    end
+    redirect_to post_path(@post), flash: { success: t('posts.update.success') } if @post.save!
   rescue => e
     handle_content_analysis_error(e)
   end
@@ -93,7 +90,7 @@ class PostsController < ApplicationController
   private
 
   def restore_search_conditions
-    [:q, :category_ids_in].each do |key|
+    %i[q category_ids_in].each do |key|
       if params[key].present?
         session[key] = params[key]
       elsif session[key].present?

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -46,7 +46,7 @@ class PostsController < ApplicationController
   def edit; end
 
   def update
-    @post.update(post_params)
+    @post.assign_attributes(post_params) # 仮代入のためupdateメソッドは使わない
     return if post_invalid
     return if content_moderated(@post)
 
@@ -54,7 +54,9 @@ class PostsController < ApplicationController
     images = params[:post][:images].present? ? params[:post][:images].reject(&:blank?) : []
     attach_resized_images(images)
 
-    redirect_to post_path(@post), flash: { success: t('posts.update.success') }
+    if @post.save! # 上記を満たせば保存
+      redirect_to post_path(@post), flash: { success: t('posts.update.success') }
+    end
   rescue => e
     handle_content_analysis_error(e)
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,7 +24,9 @@ class PostsController < ApplicationController
 
   def create
     @post = current_user.posts.build(post_params.except(:images))
-    if content_moderated?(@post.content)
+    full_text = generate_full_text(@post)
+
+    if content_moderated?(full_text)
       flash.now[:error] = moderation_message
       render :new, status: :unprocessable_entity
       return

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,6 +50,7 @@ class PostsController < ApplicationController
     return if post_invalid
     return if content_moderated(@post)
 
+    @post.images.purge
     images = params[:post][:images].present? ? params[:post][:images].reject(&:blank?) : []
     attach_resized_images(images)
 
@@ -75,12 +76,16 @@ class PostsController < ApplicationController
   end
 
   def callback
-    # OAuth認証の結果を受け取り、必要な情報をセッションに保存
-    # ここでは例として、セッションに投稿のIDを保存するコードを書く
-    session[:id] = params[:id] # 仮のコード
-    
-    # 認証が完了したら、編集ページにリダイレクト
-    redirect_to edit_post_path(session[:id])
+    if params[:post_id].present?
+      redirect_to edit_post_path(params[:post_id])
+    else
+      case params[:challenge_result]
+      when 'complete'
+        redirect_to new_post_path(challenge_result: 'complete')
+      when 'give_up'
+        redirect_to new_post_path(challenge_result: 'give_up')
+      end
+    end
   end
 
   private

--- a/app/views/posts/_crud.html.erb
+++ b/app/views/posts/_crud.html.erb
@@ -1,5 +1,5 @@
 <div class="hidden lg:flex items-center space-x-2 justify-between">
-  <%= link_to  callback_post_path, class: "flex items-center bg-blue-600 hover:bg-blue-700 text-gray-100 px-4 py-2 rounded text-sm space-x-2 transition duration-100" do %>
+  <%= link_to callback_posts_path(post_id: post.id), class: "flex items-center bg-blue-600 hover:bg-blue-700 text-gray-100 px-4 py-2 rounded text-sm space-x-2 transition duration-100" do %>
     <%= content_tag :svg, class: "w-5 h-5", xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width" => "1.5", stroke: "currentColor" do %>
       <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
     <% end %>
@@ -17,7 +17,7 @@
 
 <!--モバイル版-->
 <div class="lg:hidden flex items-center justify-between">
-  <%= link_to edit_post_path, class: "flex items-center text-blue-500 px-2 py-1 rounded text-sm space-x-2 transition duration-100" do %>
+  <%= link_to callback_posts_path(post_id: post.id), class: "flex items-center text-blue-500 px-2 py-1 rounded text-sm space-x-2 transition duration-100" do %>
     <%= content_tag :svg, class: "w-5 h-5", xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width" => "1.5", stroke: "currentColor" do %>
       <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
     <% end %>

--- a/app/views/posts/_crud.html.erb
+++ b/app/views/posts/_crud.html.erb
@@ -1,5 +1,5 @@
 <div class="hidden lg:flex items-center space-x-2 justify-between">
-  <%= link_to edit_post_path, class: "flex items-center bg-blue-600 hover:bg-blue-700 text-gray-100 px-4 py-2 rounded text-sm space-x-2 transition duration-100" do %>
+  <%= link_to  callback_post_path, class: "flex items-center bg-blue-600 hover:bg-blue-700 text-gray-100 px-4 py-2 rounded text-sm space-x-2 transition duration-100" do %>
     <%= content_tag :svg, class: "w-5 h-5", xmlns: "http://www.w3.org/2000/svg", fill: "none", viewBox: "0 0 24 24", "stroke-width" => "1.5", stroke: "currentColor" do %>
       <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
     <% end %>

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -8,7 +8,7 @@
     <label for="category" class="text-white"><%= t('posts.index.search_form.category') %></label>
     <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer md:w-48 flex items-center border-solid border border-slate-500">
       <%= t('posts.index.search_form.choose_category') %>
-      <svg class="h-5 w-5 ml-[13.8rem] md:ml-[4.5rem] text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+      <svg class="h-5 w-5 ml-60 md:ml-[4.5rem] text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
       </svg>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,9 +4,9 @@
   </div>
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">
     <% @posts.each do |post| %>
-    <div class="overflow-hidden transition-shadow duration-300 bg-white rounded p-8 bg-white border rounded relative">
-      <%= image_tag(post.display_image, style: "width: 390px; height: 300px; object-fit: cover;") %>
-      <div class="py-5">
+    <div class="overflow-hidden transition-shadow duration-300 bg-white rounded py-8 bg-white border rounded relative flex flex-col items-center">
+      <%= image_tag(post.display_image, style: 'width: 250px; height: 250px; object-fit: cover;') %>
+      <div class="flex flex-col py-5 w-3/4">
         <p class="mb-2 text-xs font-semibold text-gray-600 uppercase"><%= post.created_at.strftime('%Y/%m/%d %H:%M') %></p>
         <div class="flex space-x-2 items-center mb-6">
           <div class="w-12 h-12">
@@ -17,20 +17,21 @@
           <h2 class="text-base text-black"><%= truncate(post.user.username, length: 15) %></h2>
         </div>
 
-        <div class="flex justify-center">
+        <div class="flex flex-col justify-center items-center">
           <%= render 'challenge_result', { post: post } %>
-        </div>
+        
 
         <div class="nline-block my-3 text-black transition-colors duration-200 hover:text-deep-purple-accent-700">
           <p class="text-xl leading-5"><%= truncate(post.title, length: 28) %></p>
         </div>
         <p class="mb-4 text-gray-700"><%= truncate(post.content, length: 51) %></p>
-
-        <div class="text-center my-4">
-          <%= link_to 'Read more', post_path(post), class: 'inline-flex items-center font-semibold transition-colors duration-200 text-blue-700 hover:text-blue-400 underline' %>
         </div>
 
-        <div class="flex space-x-2 absolute bottom-5 left-5 right-3">
+        <div class="text-center my-4">
+          <%= link_to 'Read more', post_path(post), class: 'inline-flex items-center font-semibold transition-colors duration-200 text-blue-700 hover:text-blue-400 underline mb-3' %>
+        </div>
+
+        <div class="flex space-x-2 absolute bottom-5 left-10 right-3">
           <% case post.challenge_result %>
           <% when 'complete' %>
             <%= image_tag 'likes/crazy_1.png', class: 'h-10 w-10' %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,12 +19,11 @@
 
         <div class="flex flex-col justify-center items-center">
           <%= render 'challenge_result', { post: post } %>
-        
 
-        <div class="nline-block my-3 text-black transition-colors duration-200 hover:text-deep-purple-accent-700">
-          <p class="text-xl leading-5"><%= truncate(post.title, length: 28) %></p>
-        </div>
-        <p class="mb-4 text-gray-700"><%= truncate(post.content, length: 51) %></p>
+          <div class="nline-block my-3 text-black transition-colors duration-200 hover:text-deep-purple-accent-700">
+            <p class="text-xl leading-5"><%= truncate(post.title, length: 28) %></p>
+          </div>
+          <p class="mb-4 text-gray-700"><%= truncate(post.content, length: 51) %></p>
         </div>
 
         <div class="text-center my-4">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,10 +21,10 @@
             <button type="button" class="text-black transition hover:text-white pl-6" data-action="click->dropdown#toggleMenu">POST</button>
             <ul class="hidden absolute w-48 bg-white shadow-md mt-2 rounded-md py-1" data-dropdown-target="menu">
               <li>
-                <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
+                <%= link_to 'COMPLETE', callback_posts_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
               </li>
               <li>
-                <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
+                <%= link_to 'GIVE UP', callback_posts_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
               </li>
             </ul>
           </li>
@@ -63,10 +63,10 @@
           <button type="button" class="text-white transition" data-action="click->dropdown#toggleMenu">POST</button>
           <ul class="hidden absolute w-48 bg-white shadow-md mt-2 rounded-md" data-dropdown-target="menu">
             <li>
-              <%= link_to 'COMPLETE', new_post_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
+              <%= link_to 'COMPLETE', callback_posts_path(challenge_result: 'complete'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
             </li>
             <li>
-              <%= link_to 'GIVE UP', new_post_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
+              <%= link_to 'GIVE UP', callback_posts_path(challenge_result: 'give_up'), class:'block px-4 py-2 text-sm text-slate-950 transition hover:bg-gray-300' %>
             </li>
           </ul>
         </li>

--- a/app/views/top_pages/top.html.erb
+++ b/app/views/top_pages/top.html.erb
@@ -9,8 +9,10 @@
               <p class="text-white text-sm">クレイジーな挑戦に挑んだ君へ</p>
             </div>
             <div class="flex flex-col gap-3 mt-3">
-              <%= link_to 'はじめる', login_path, class:'text-white bg-black mx-auto w-32 text-center rounded-md p-2 border border-1 border-red-500 hover:bg-red-700' %>
-              <%= link_to '会員登録はこちら', new_user_path, class:'text-gray-400 text-sm hover:text-white' %>
+              <% unless logged_in? %>
+                <%= link_to 'はじめる', login_path, class:'text-white bg-black mx-auto w-32 text-center rounded-md p-2 border border-1 border-red-500 hover:bg-red-700' %>
+                <%= link_to '会員登録はこちら', new_user_path, class:'text-gray-400 text-sm hover:text-white' %>
+              <% end %>
             </div>
         </div>
       </div>
@@ -202,8 +204,10 @@
             <p class="text-white text-sm">君の挑戦を聞かせてくれ</p>
           </div>
           <div class="flex justify-center space-x-4 lg:spac-x-0">
-            <%= link_to 'LOGIN', login_path, class:'bg-gray-50 mx-auto w-32 text-center rounded-md p-2 border border-1 border-gray-100 hover:bg-sky-300' %>
-            <%= link_to 'SIGN UP', new_user_path, class:'bg-gray-50 mx-auto w-32 text-center rounded-md p-2 border border-1 border-gray-100 hover:bg-sky-300' %>
+            <% unless logged_in? %>
+              <%= link_to 'LOGIN', login_path, class:'bg-gray-50 mx-auto w-32 text-center rounded-md p-2 border border-1 border-gray-100 hover:bg-sky-300' %>
+              <%= link_to 'SIGN UP', new_user_path, class:'bg-gray-50 mx-auto w-32 text-center rounded-md p-2 border border-1 border-gray-100 hover:bg-sky-300' %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,8 +22,6 @@ Rails.application.routes.draw do
     collection do
       get 'ranking'
       get 'reset_search'
-    end
-    member do
       get 'callback'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,5 +23,8 @@ Rails.application.routes.draw do
       get 'ranking'
       get 'reset_search'
     end
+    member do
+      get 'callback'
+    end
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -149,11 +149,11 @@ RSpec.describe "Posts", type: :system do
 
       it '有害な投稿内容を含むとNatural language APIにより投稿阻止' do
         click_on 'COMPLETE'
-        fill_in 'post[title]', with: 'title'
-        fill_in 'post[content]', with: '死・犯罪・災害・戦争・暴力・薬物' # 挑戦内容に有害な単語を記載
-        fill_in 'post[record]', with: 'record'
-        fill_in 'post[impression_event]', with: 'implession_event'
-        fill_in 'post[lesson]', with: 'lesson'
+        fill_in 'post[title]', with: '死'
+        fill_in 'post[content]', with: '災害' # 挑戦内容に有害な単語を記載
+        fill_in 'post[record]', with: '暴力'
+        fill_in 'post[impression_event]', with: '戦争'
+        fill_in 'post[lesson]', with: '大麻'
         check_categories('1', '2', '3')
         upload_images('crazy_1.png', 'default.png', 'nice_fight_1.png', 'stop_1.png')
         using_wait_time(4) do

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe "Posts", type: :system do
       link = "/posts/#{post_id}"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
-      link = "/posts/#{post_id}/callback"
+      link = "/posts/callback?post_id=#{post_id}"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
       fill_in 'post[title]', with: 'edit_title'
@@ -204,7 +204,7 @@ RSpec.describe "Posts", type: :system do
       link = "/posts/#{post_id}"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
-      link = "/posts/#{post_id}/callback"
+      link = "/posts/callback?post_id=#{post_id}"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
       fill_in 'post[title]', with: '死'
@@ -307,7 +307,6 @@ RSpec.describe "Posts", type: :system do
         link = "/posts/#{post_id}"
         expect(page).to have_selector("a[href='#{link}']")
         find("a[href='#{link}']").click
-        link = "/posts/#{post_id}/likes"
         expect(page).to have_content('冒険・探究')
       end
 

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "Posts", type: :system do
       it '有害な投稿内容を含むとNatural language APIにより投稿阻止' do
         click_on 'COMPLETE'
         fill_in 'post[title]', with: '死'
-        fill_in 'post[content]', with: '災害' # 挑戦内容に有害な単語を記載
+        fill_in 'post[content]', with: '災害'
         fill_in 'post[record]', with: '暴力'
         fill_in 'post[impression_event]', with: '戦争'
         fill_in 'post[lesson]', with: '大麻'
@@ -174,7 +174,7 @@ RSpec.describe "Posts", type: :system do
       link = "/posts/#{post_id}"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
-      link = "/posts/#{post_id}/edit"
+      link = "/posts/#{post_id}/callback"
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
       fill_in 'post[title]', with: 'edit_title'
@@ -197,6 +197,25 @@ RSpec.describe "Posts", type: :system do
       expect(page).to have_selector("a[href='#{link}']")
       find("a[href='#{link}']").click
       have_no_content('編集')
+    end
+
+    it '有害な投稿内容を含むとNatural language APIにより投稿阻止' do
+      post_id = complete_post.id
+      link = "/posts/#{post_id}"
+      expect(page).to have_selector("a[href='#{link}']")
+      find("a[href='#{link}']").click
+      link = "/posts/#{post_id}/callback"
+      expect(page).to have_selector("a[href='#{link}']")
+      find("a[href='#{link}']").click
+      fill_in 'post[title]', with: '死'
+      fill_in 'post[content]', with: '災害'
+      fill_in 'post[record]', with: '暴力'
+      fill_in 'post[impression_event]', with: '戦争'
+      fill_in 'post[lesson]', with: '大麻'
+      using_wait_time(4) do
+        click_on '更新する'
+        expect(page).to have_content('不適切なコンテンツが含まれています：死や害・ 冒とく・ 違法ドラッグ・ 戦争')
+      end
     end
   end
 


### PR DESCRIPTION
概要
既存の設計は、createアクションのcontentカラムにのみAPIを導入していた。
それをtitel・contente・record・impression_event・lessonカラムに導入した（その他のカラムは文章入力ではない）。

その際、google cloudの「承認済みのリダイレクト URI」部分には、updateアクションのような動的uriを登録することが
できないため、callbackアクションを経由してupdateアクションでもOauth2.0を利用できるようにした。
不要なuri登録を避けるため、createアクションでもcallbackアクションを経由することにした。

既存の内容ではAPIの解析の後、バリデーションチェックをしていたが、不要なAPIの呼び出しをさけるため
createアクションとupdateアクションともに、バリデーションチェックの後にAPI解析の実行へと変更した。

fat_controllerを避ける目的から、APIの解析に関する内容はpost_moderation_concern.rbにまとめた。
バリデーションのチェックも投稿内容をチェックすることから、API解析と目的は似ているため
コードの軽量化も兼ねて、post_moderation_concern.rbにメソッドを追加した。

createアクションとupdateアクションともに、バリデーションのチェックのため
@postにて画像も一度取り込むが、リサイズする際に既存の画像とリサイズ画像の両方を@postに格納しないよう
APIの解析後は、@postに含まれる画像を削除している。
updateアクションにおいては、画像を削除する前に`@post.reload`を追加しないと思い通りの処理が実現できなかった。

updateアクションでは、updateアクションの利用は避け、バリデーションとAPI解析がパスしたsaveするよう実装した。
更新が拒否された際に、キャンセルやブラウザの戻るボタンを押すことで拒否された投稿が反映されないようにするため。

Close #90 
Close #106 