### PR TITLE
プロフィール画像やその他バグの修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ give upした挑戦は達成できてないため、ランキング化はしま�
 https://www.figma.com/file/bYm3gAgfyFwbDCRwKpCDT3/crazy_challenge_record?type=design&node-id=0%3A1&mode=design&t=Y6dHQ2dFwSjpMyqN-1
 
 ### ER図
-[![Image from Gyazo](https://i.gyazo.com/6f36486c5bc8b9ba6933bde53ccb55a0.png)](https://gyazo.com/6f36486c5bc8b9ba6933bde53ccb55a0)
+[![Image from Gyazo](https://i.gyazo.com/401a6eb9edd54b3c5fdf8f2a3606d270.png)](https://gyazo.com/401a6eb9edd54b3c5fdf8f2a3606d270)

--- a/app/controllers/concerns/image_processing_concern.rb
+++ b/app/controllers/concerns/image_processing_concern.rb
@@ -8,13 +8,11 @@ module ImageProcessingConcern
                           .source(image.tempfile)
                           .convert('jpg') # HEICをJPEGに変換
                           .resize_to_limit(width, height)
-                          .saver(quality: 80)
                           .call
     else
       processed_image = ::ImageProcessing::Vips
                           .source(image.tempfile)
                           .resize_to_limit(width, height)
-                          .saver(quality: 80)
                           .call
     end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,7 +30,7 @@ class PostsController < ApplicationController
     @post.images.purge # オリジナル画像とリサイズ画像の両方を保存させないため
     attach_resized_images(params[:post][:images].reject(&:blank?)) if params[:post][:images].reject(&:blank?).present?
 
-    redirect_to posts_path, flash: { success: t('posts.create.success') } if @post.save!
+    redirect_to post_path(@post), flash: { success: t('posts.create.success') } if @post.save!
   rescue => e
     handle_content_analysis_error(e)
   end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -3,7 +3,17 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
+  process :convert_heic_to_jpeg
   process :conditional_resize
+
+  def convert_heic_to_jpeg
+    if file.extension.downcase == 'heic'
+      cache_stored_file! if !cached?
+      image = MiniMagick::Image.open(current_path)
+      image.format('jpg')
+      image.write(current_path)
+    end
+  end
 
   def conditional_resize
     image = MiniMagick::Image.open(file.path)

--- a/app/uploaders/background_uploader.rb
+++ b/app/uploaders/background_uploader.rb
@@ -3,7 +3,17 @@ class BackgroundUploader < CarrierWave::Uploader::Base
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
 
+  process :convert_heic_to_jpeg
   process :conditional_resize
+
+  def convert_heic_to_jpeg
+    if file.extension.downcase == 'heic'
+      cache_stored_file! if !cached?
+      image = MiniMagick::Image.open(current_path)
+      image.format('jpg')
+      image.write(current_path)
+    end
+  end
 
   def conditional_resize
     image = MiniMagick::Image.open(file.path)
@@ -41,9 +51,9 @@ class BackgroundUploader < CarrierWave::Uploader::Base
 
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_allowlist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_allowlist
+    %w[jpg jpeg gif png]
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -6,9 +6,9 @@
 
   <div class="form-group mb-1" data-controller="dropdown-multiselect">
     <label for="category" class="text-white"><%= t('posts.index.search_form.category') %></label>
-    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer md:w-48 flex items-center border-solid border border-slate-500">
-      <%= t('posts.index.search_form.choose_category') %>
-      <svg class="h-5 w-5 ml-60 md:ml-[4.5rem] text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <div data-target="dropdown-multiselect.dropdown" data-action="click->dropdown-multiselect#toggleDropdownMenu" class="dropdown bg-white p-2 rounded cursor-pointer md:w-48 flex justify-between items-center border-solid border border-slate-500">
+      <span><%= t('posts.index.search_form.choose_category') %></span>
+      <svg class="h-5 w-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
       </svg>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,7 +5,11 @@
   <div class="grid gap-5 lg:grid-cols-4 sm:max-w-sm sm:mx-auto lg:max-w-full">
     <% @posts.each do |post| %>
     <div class="overflow-hidden transition-shadow duration-300 bg-white rounded py-8 bg-white border rounded relative flex flex-col items-center">
-      <%= image_tag(post.display_image, style: 'width: 250px; height: 250px; object-fit: cover;') %>
+      <% if post.images.present? %>
+      <%= image_tag post.images.first, class: 'h-72 w-72 object-cover' %>
+      <% else %>
+      <%= image_tag post.display_image, class: 'h-72 w-72 object-cover' %>
+      <% end %>
       <div class="flex flex-col py-5 w-3/4">
         <p class="mb-2 text-xs font-semibold text-gray-600 uppercase"><%= post.created_at.strftime('%Y/%m/%d %H:%M') %></p>
         <div class="flex space-x-2 items-center mb-6">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<div class="px-4 py-5 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-8 md:pb-10 md:pt-5 min-h-screen" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="px-4 py-5 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-2xl md:px-8 md:pb-10 md:pt-5 min-h-screen bg-fixed" style="background-image: url('<%= image_path('post.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover;">
   <div class="mb-10">
     <%= render 'search_form' %>
   </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,5 @@
 <!-- component -->
-<div class="flex py-10 w-full items-center justify-center bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="flex py-10 w-full items-center justify-center bg-cover bg-no-repeat bg-fixed" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover;">
   <div class="rounded-xl bg-gray-800 bg-opacity-50 px-16 py-10 shadow-lg backdrop-blur-md max-sm:px-8">
     <div class="text-white">
       <div class="flex flex-col items-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <!-- component -->
-<div class="flex w-full items-center justify-center bg-cover bg-no-repeat" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover; background-attachment: fixed;">
+<div class="flex w-full items-center justify-center bg-cover bg-no-repeat bg-fixed" style="background-image:url('<%= image_path('top.jpeg') %>'); background-position: center; background-repeat: no-repeat; background-size: cover;">
   <div class="rounded-xl bg-gray-800 bg-opacity-50 px-16 my-10 shadow-lg backdrop-blur-md max-sm:px-8">
     <div class="text-white">
       <div class="flex flex-col items-center">

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe "Posts", type: :system do
         upload_images('crazy_1.png', 'default.png', 'nice_fight_1.png', 'stop_1.png')
         click_on '投稿する'
         using_wait_time(4) do
-          expect(page).to have_current_path(posts_path)
           expect(page).to have_content('新規投稿されました')
         end
       end
@@ -42,7 +41,6 @@ RSpec.describe "Posts", type: :system do
         upload_images('crazy_1.png', 'default.png', 'nice_fight_1.png', 'stop_1.png')
         click_on '投稿する'
         using_wait_time(4) do
-          expect(page).to have_current_path(posts_path)
           expect(page).to have_content('新規投稿されました')
         end
       end


### PR DESCRIPTION
概要
本番環境においてユーザーのプロフィール画像のバグが発生する。
その原因がHEIC形式の画像であると推測した。Iphone画像がHEIC形式であるため。
なのでuploaderにおいてavatarとbackgroundともにHEIC形式の画像をjpgに変換するロジックを追加した。

投稿一覧・ログイン・会員登録画面の背景画像がバグを起こし、本来は画像がスクロールしても固定されてる
`background-attachment: fixed;`の設定を追加してたが、iOSでは適用されないことが判明した。
なので`bg-fixed`に変更した。

また、投稿一覧の表示画像の画質が荒かく、当初の`<%= image_tag(post.display_image,`が原因であると判明し修正した。

新規作成後の遷移先が投稿一覧になっていたが、投稿詳細に変更した。

当初、投稿時の画像リサイズ時に画質を80%に低減し、表示時のメモリ負担を減らす目的で`saver(quality: 80)`を
実装したが、当該実装の有無によりメモリサイズの変化が乏しかったので、無駄に画質のクオリティーを下げることを
防ぐため、当該実装を削除した。

#107 
