### PR TITLE
consumer.jsの追加忘れの修正

### DIFF
--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,2 +1,3 @@
 // Import all the channels to be used by Action Cable
 import "channels/chat_channel"
+import "channels/consumer"


### PR DESCRIPTION
本番環境にて以下のエラーが発生したため修正した
```
GET https://fierce-plateau-48229-09e6d0eb36ec.herokuapp.com/assets/channels/consumer net::ERR_ABORTED 404 (Not Found)
```