### PR TITLE
アバター設定などの修正

### DIFF
--- a/app/javascript/channels/chat_channel.js
+++ b/app/javascript/channels/chat_channel.js
@@ -68,6 +68,8 @@ function buildAvatarContent(data, isSender) {
 
   if (!isSender && !isPreviousTime) {
     return `<img src="${data.sender_avatar_url}" class="flex items-center justify-center h-10 w-10 rounded-full flex-shrink-0">`;
+  } else if (!isSender && isPreviousTime) {
+    return `<div class="h-10 w-10 flex-shrink-0"></div>`;
   }
   return '';
 }

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -38,7 +38,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
 
   # Provide a default URL as a default if there hasn't been a file uploaded:
   def default_url
-    'default.png'
+    ActionController::Base.helpers.asset_path('default.png')
   end
 
   # Process files as they are uploaded:


### PR DESCRIPTION
Uploaderのdefault urlメソッドが本番環境で表示されなかったため、内容を修正した。
また、送信者が同時刻にメッセージを表示したらアバターを省略し、アバター文の余白をあけられるよう実装を修正した。

Close #108 